### PR TITLE
Memory Load

### DIFF
--- a/covid_19/add_to_indra_db.py
+++ b/covid_19/add_to_indra_db.py
@@ -11,7 +11,7 @@ from indra_db.managers.content_manager import PmcManager, ContentManager
 from covid_19.get_indra_stmts import get_unique_text_refs, get_metadata_dict, \
                                      cord19_metadata_for_trs
 from covid_19.preprocess import get_text_refs_from_metadata, \
-                                get_zip_texts_for_entry, download_latest_data
+    get_zip_texts_for_entry, download_latest_data, get_all_texts
 from indra_db.databases import sql_expressions as sql_exp
 
 
@@ -36,6 +36,7 @@ class Cord19Manager(ContentManager):
                         'content',)
         self.review_fname = 'cord19_mgr_review.txt'
 
+        texts_by_file = get_all_texts()
         # Get tr_data list from Cord19 metadata
         # tr_data is a list [{'pmid': xxx, 'pmcid': xxx}, {...}]
         # tc_data is a list of dictionaries keyed by column name (???)
@@ -51,7 +52,7 @@ class Cord19Manager(ContentManager):
                              'doi': doi,
                              'cord_uid': text_refs.get('CORD19_UID')}
             # If has abstract, add TC entry with abstract content
-            tc_texts = get_zip_texts_for_entry(md_entry)
+            tc_texts = get_zip_texts_for_entry(md_entry, texts_by_file)
             for source, text_type, text in tc_texts:
                 tc_data_entry = {'source': source,
                                  'format': 'text',

--- a/covid_19/find_mutations.py
+++ b/covid_19/find_mutations.py
@@ -1,7 +1,7 @@
 import re
 import csv
 from covid_19.preprocess import get_metadata_dict, get_zip_texts_for_entry, \
-                                get_metadata_df
+                                get_metadata_df, get_all_texts
 from indra_db import get_primary_db
 
 
@@ -39,6 +39,7 @@ ignore_list = (
 )
 
 
+texts_by_file = get_all_texts()
 by_mut = {}
 by_doc = {}
 for ix, md_entry in enumerate(md):
@@ -46,7 +47,7 @@ for ix, md_entry in enumerate(md):
     title = md_entry['title']
     if pmid not in covid_pmids:
         continue
-    texts = get_zip_texts_for_entry(md_entry, zip=False)
+    texts = get_zip_texts_for_entry(md_entry, texts_by_file, zip=False)
     cord_uid = md_entry['cord_uid']
     for _, text_type, text in texts:
         matches = re.findall(mut_reg, text, flags=re.IGNORECASE)

--- a/covid_19/preprocess.py
+++ b/covid_19/preprocess.py
@@ -63,7 +63,19 @@ def download_latest_data():
     logger.info('Latest data is available in %s'  % basepath)
 
 
-def get_zip_texts_for_entry(md_entry, zip=True):
+def get_all_texts():
+    """Return a dictionary mapping json filenames with full text contents."""
+    texts_by_file = {}
+    logger.info('Extracting full texts from all document json files...')
+    tar = tarfile.open(doc_gz_path)
+    members = tar.getmembers()
+    for m in members:
+        f = tar.extractfile(m)
+        doc_json = json.loads(f.read().decode('utf-8'))
+        text = get_text_from_json(doc_json)
+        texts_by_file[m.name] = text
+    tar.close()
+    return texts_by_file
     texts = []
     if md_entry['pdf_json_files']:
         filenames = [s.strip() for s in md_entry['pdf_json_files'].split(';')]

--- a/covid_19/preprocess.py
+++ b/covid_19/preprocess.py
@@ -76,19 +76,28 @@ def get_all_texts():
         texts_by_file[m.name] = text
     tar.close()
     return texts_by_file
+
+
+def get_zip_texts_for_entry(md_entry, texts_by_file, zip=True):
     texts = []
     if md_entry['pdf_json_files']:
         filenames = [s.strip() for s in md_entry['pdf_json_files'].split(';')]
         pdf_texts = []
         for filename in filenames:
-            pdf_texts.append(get_text_from_json(filename))
+            if texts_by_file.get(filename):
+                pdf_texts.append(texts_by_file[filename])
+            else:
+                logger.warning('Text for %s is missing'  % filename)
         combined_text = '\n'.join(pdf_texts)
         if zip:
             combined_text = zip_string(combined_text)
         texts.append(('cord19_pdf', 'fulltext', combined_text))
     if md_entry['pmc_json_files']:
         filename = md_entry['pmc_json_files']
-        text = get_text_from_json(filename)
+        if texts_by_file.get(filename):
+            text = texts_by_file[filename]
+        else:
+            logger.warning('Text for %s is missing'  % filename)
         if zip:
             text = zip_string(text)
         texts.append(('cord19_pmc_xml', 'fulltext', text))
@@ -162,11 +171,7 @@ def get_ids(id_type):
     return unique_ids
 
 
-def get_text_from_json(json_filename):
-    tar = tarfile.open(doc_gz_path)
-    f = tar.extractfile(tar.getmember(json_filename))
-    doc_json = json.loads(f.read().decode('utf-8'))
-    tar.close()
+def get_text_from_json(doc_json):
     text = ''
     text += doc_json['metadata']['title']
     text += '.\n'
@@ -184,7 +189,7 @@ def get_text_from_json(json_filename):
 
 
 def dump_text_files(output_dir, doc_df):
-    # TODO this needs to be updated with new df structure
+    # TODO this needs to be updated with new df structure and code updates
     sha_ix = 1
     path_ix = 15
     title_ix = 3

--- a/covid_19/preprocess.py
+++ b/covid_19/preprocess.py
@@ -257,6 +257,9 @@ def get_text_refs_from_metadata(entry):
         if val and not pd.isnull(val):
             if key == 'doi':
                 val = fix_doi(val)
+            elif key == 'pubmed_id':
+                if val is not None and not val.isdigit():
+                    val = None
             # Temporary patch to remove float suffixes
             if val.endswith('.0'):
                 val = val[:-2]

--- a/covid_19/preprocess.py
+++ b/covid_19/preprocess.py
@@ -5,8 +5,8 @@ import json
 import time
 import re
 import urllib
-import shutil
 import logging
+import tarfile
 from os.path import abspath, dirname, join, isdir
 import pandas as pd
 from indra.util import zip_string
@@ -34,6 +34,7 @@ latest_date = get_latest_available_date()  # For processing latest data
 data_dir = join(dirname(abspath(__file__)), '..', 'data')
 basepath = join(data_dir, latest_date)
 metadata_file = join(basepath, 'metadata.csv')
+doc_gz_path = os.path.join(basepath, 'document_parses.tar.gz')
 doc_df = None
 
 
@@ -54,16 +55,11 @@ def download_metadata():
 def download_latest_data():
     """Download metadata and document parses."""
     download_metadata()
-    doc_gz_path = os.path.join(basepath, 'document_parses.tar.gz')
-    doc_path = os.path.join(basepath, 'document_parses', 'pdf_json')
+    
     if not os.path.exists(doc_gz_path):
         logger.info('Downloading document parses')
         doc_url = baseurl + '%s/document_parses.tar.gz'  % latest_date
         urllib.request.urlretrieve(doc_url, doc_gz_path)
-    # Separately check for unpacked directory in case the load was interrupted
-    if not os.path.exists(doc_path):
-        logger.info('Unpacking document parses')
-        shutil.unpack_archive(doc_gz_path, basepath)
     logger.info('Latest data is available in %s'  % basepath)
 
 
@@ -73,16 +69,14 @@ def get_zip_texts_for_entry(md_entry, zip=True):
         filenames = [s.strip() for s in md_entry['pdf_json_files'].split(';')]
         pdf_texts = []
         for filename in filenames:
-            content_path = join(basepath, filename)
-            pdf_texts.append(get_text_from_json(content_path))
+            pdf_texts.append(get_text_from_json(filename))
         combined_text = '\n'.join(pdf_texts)
         if zip:
             combined_text = zip_string(combined_text)
         texts.append(('cord19_pdf', 'fulltext', combined_text))
     if md_entry['pmc_json_files']:
         filename = md_entry['pmc_json_files']
-        content_path = join(basepath, filename)
-        text = get_text_from_json(content_path)
+        text = get_text_from_json(filename)
         if zip:
             text = zip_string(text)
         texts.append(('cord19_pmc_xml', 'fulltext', text))
@@ -157,8 +151,10 @@ def get_ids(id_type):
 
 
 def get_text_from_json(json_filename):
-    with open(json_filename, 'rt') as f:
-        doc_json = json.load(f)
+    tar = tarfile.open(doc_gz_path)
+    f = tar.extractfile(tar.getmember(json_filename))
+    doc_json = json.loads(f.read().decode('utf-8'))
+    tar.close()
     text = ''
     text += doc_json['metadata']['title']
     text += '.\n'
@@ -176,6 +172,7 @@ def get_text_from_json(json_filename):
 
 
 def dump_text_files(output_dir, doc_df):
+    # TODO this needs to be updated with new df structure
     sha_ix = 1
     path_ix = 15
     title_ix = 3


### PR DESCRIPTION
This PR reimplements extracting texts from the document parses files. The `document_parses.tar.gz` is no longer unpacked into dick, instead the `tarfile` package is used to read all texts from all inner files and store them in the dictionary keyed by filenames. This dictionary is then used to map the metadata entries to corresponding texts.