### PR TITLE
VirHostNet, CTD scripts and emmaa_update generalization

### DIFF
--- a/covid_19/emmaa_update.py
+++ b/covid_19/emmaa_update.py
@@ -101,6 +101,7 @@ if __name__ == '__main__':
     #            -d stmts/drug_stmts.pkl \
     #            -g stmts/gordon_ndex_stmts.pkl \
     #            -v stmts/virhostnet_stmts.pkl \
+    #            -c stmts/ctd_stmts.pkl
     #            -f stmts/cord19_combined_stmts.pkl
     parser = argparse.ArgumentParser(
             description='Put together updated statement pkl for COVID-19 '
@@ -120,6 +121,9 @@ if __name__ == '__main__':
     parser.add_argument('-v', '--virhostnet_stmts',
                         help='Path to VirHostNet statements pkl file',
                         required=True)
+    parser.add_argument('-c', '--ctd_stmts',
+                        help='Path to CTD statements pkl file',
+                        required=True)
     parser.add_argument('-f', '--output_file',
                          help='Output file for combined pkl',
                          required=True)
@@ -137,8 +141,9 @@ if __name__ == '__main__':
     drug_stmts = ac.load_statements(args.drug_stmts)
     gordon_stmts = ac.load_statements(args.gordon_stmts)
     virhostnet_stmts = ac.load_statements(args.virhostnet_stmts)
+    ctd_stmts = ac.load_statements(args.ctd_stmts)
 
-    other_stmts = drug_stmts + gordon_stmts + virhostnet_stmts
+    other_stmts = drug_stmts + gordon_stmts + virhostnet_stmts + ctd_stmts
 
     combined_stmts = make_model_stmts(
         old_mm_stmts, other_stmts, new_cord_stmts)

--- a/covid_19/emmaa_update.py
+++ b/covid_19/emmaa_update.py
@@ -90,6 +90,7 @@ def make_model_stmts(old_mm_stmts, other_stmts, new_cord_stmts=None):
 
     # Now, add back in all other statements
     combined_stmts = updated_mm_stmts + other_stmts
+    logger.info('Got %d total statements.' % len(combined_stmts))
     return combined_stmts
 
 if __name__ == '__main__':

--- a/covid_19/emmaa_update.py
+++ b/covid_19/emmaa_update.py
@@ -36,8 +36,26 @@ def combine_stmts(new_cord_by_tr, old_mm_by_tr):
     return stmts_copy
 
 
-def make_model_stmts(old_mm_stmts, drug_stmts, gordon_stmts,
-                     new_cord_stmts=None):
+def make_model_stmts(old_mm_stmts, other_stmts, new_cord_stmts=None):
+    """Process and combine statements from different resources.
+
+    Parameters
+    ----------
+    old_mm_stmts : list[indra.statements.Statement]
+        A list of statements currently in the model.
+    other_stmts : list[indra.statements.Statement]
+        A list of statements that do not need additional processing
+        (e.g. drug, gordon, virhostnet statements).
+    new_cord_stmts : Optional[list[indra.statements.Statement]]
+        A list of newly extracted statements from CORD19 corpus. If not
+        provided, the statements are pulled from the database and filtered
+        to those not in old_mm_stmts.
+    
+    Returns
+    -------
+    combined_stmts : list[indra.statements.Statement]
+        A list of statements to make a new model from.
+    """
     # If new cord statements are not provided, load from database
     if not new_cord_stmts:
         # Get text refs from metadata
@@ -70,8 +88,8 @@ def make_model_stmts(old_mm_stmts, drug_stmts, gordon_stmts,
     updated_mm_stmts = [s for stmt_list in updated_mm_stmts_by_tr.values()
                           for s in stmt_list]
 
-    # Now, add back in the drug stmts and Gordon PPI stmts
-    combined_stmts = updated_mm_stmts + drug_stmts + gordon_stmts
+    # Now, add back in all other statements
+    combined_stmts = updated_mm_stmts + other_stmts
     return combined_stmts
 
 if __name__ == '__main__':
@@ -81,6 +99,7 @@ if __name__ == '__main__':
     #            -nc stmts/cord19_all_db_raw_stmts.pkl \
     #            -d stmts/drug_stmts.pkl \
     #            -g stmts/gordon_ndex_stmts.pkl \
+    #            -v stmts/virhostnet_stmts.pkl \
     #            -f stmts/cord19_combined_stmts.pkl
     parser = argparse.ArgumentParser(
             description='Put together updated statement pkl for COVID-19 '
@@ -89,7 +108,7 @@ if __name__ == '__main__':
                         help='Name of old EMMAA model pkl file',
                         required=True)
     parser.add_argument('-nc', '--new_cord',
-                        help='Name of new CORD-19 DB stmts pkl file',
+                        help='Name of new CORD-19 DB stmts pkl file (optional)',
                         required=False)
     parser.add_argument('-d', '--drug_stmts',
                          help='Path to drug statements pkl file',
@@ -97,6 +116,9 @@ if __name__ == '__main__':
     parser.add_argument('-g', '--gordon_stmts',
                          help='Path to Gordon statements pkl file',
                          required=True)
+    parser.add_argument('-v', '--virhostnet_stmts',
+                        help='Path to VirHostNet statements pkl file',
+                        required=True)
     parser.add_argument('-f', '--output_file',
                          help='Output file for combined pkl',
                          required=True)
@@ -113,9 +135,12 @@ if __name__ == '__main__':
         new_cord_stmts = None
     drug_stmts = ac.load_statements(args.drug_stmts)
     gordon_stmts = ac.load_statements(args.gordon_stmts)
+    virhostnet_stmts = ac.load_statements(args.virhostnet_stmts)
+
+    other_stmts = drug_stmts + gordon_stmts + virhostnet_stmts
 
     combined_stmts = make_model_stmts(
-        old_mm_stmts, drug_stmts, gordon_stmts, new_cord_stmts)
+        old_mm_stmts, other_stmts, new_cord_stmts)
 
     # Dump new pickle
     ac.dump_statements(combined_stmts, args.output_file)

--- a/covid_19/process_ctd.py
+++ b/covid_19/process_ctd.py
@@ -1,0 +1,84 @@
+import logging
+import pickle
+import argparse
+import os
+from indra.tools import assemble_corpus as ac
+from emmaa.model import get_assembled_statements
+from emmaa.model_tests import load_tests_from_s3
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_all_groundings(stmts):
+    groundings = set()
+    for stmt in stmts:
+        for ag in stmt.agent_list():
+            if ag is not None:
+                gr = ag.get_grounding()
+                if gr != (None, None):
+                    groundings.add(gr)
+    return groundings
+
+
+def filter_by_groundings(stmts, groundings, policy='any'):
+    logger.info('Filtering %d statements to those that have %s agents '
+                'grounded to one of %d groundings.'
+                % (len(stmts), policy, len(groundings)))
+    stmts_out = []
+    for stmt in stmts:
+        ag_groundings = [
+            ag.get_grounding() for ag in stmt.agent_list() if ag is not None]
+        if policy == 'any':
+            if any([ag_gr in groundings for ag_gr in ag_groundings]):
+                stmts_out.append(stmt)
+        elif policy == 'all':
+            if all([ag_gr in groundings for ag_gr in ag_groundings]):
+                stmts_out.append(stmt)
+    logger.info('%d statements after filter' % len(stmts_out))
+    return stmts_out
+
+
+if __name__ == '__main__':
+    # Example:
+    # python covid_19/process_ctd.py \
+    #       -cd stmts/ctd_chemical_disease.pkl
+    #       -cg stmts/ctd_chemical_gene.pkl
+    #       -gd stmts/ctd_gene_disease.pkl
+    parser = argparse.ArgumentParser(
+        description='Filter CTD statements to include in EMMAA COVID-19 model')
+    parser.add_argument('-cd', '--chemical_disease',
+                        help='Path to ctd chemical disease statements pkl',
+                        required=True)
+    parser.add_argument('-cg', '--chemical_gene',
+                        help='Path to ctd chemical gene statements pkl',
+                        required=True)
+    parser.add_argument('-gd', '--gene_disease',
+                        help='Path to ctd gene disease statements pkl',
+                        required=True)
+    args = parser.parse_args()
+
+    # Load model statements and tests
+    model_stmts = get_assembled_statements('covid19')
+    curated_tests, _ = load_tests_from_s3('covid19_curated_tests')
+    if isinstance(curated_tests, dict):  # if descriptions were added
+        curated_tests = curated_tests['tests']
+    mitre_tests, _ = load_tests_from_s3('covid19_mitre_tests')
+    if isinstance(mitre_tests, dict):  # if descriptions were added
+        mitre_tests = mitre_tests['tests']
+    all_model_stmts = model_stmts + [test.stmt for test in curated_tests] + \
+        [test.stmt for test in mitre_tests]
+
+    # Load CTD statements
+    chem_dis_stmts = ac.load_statements(args.chemical_disease)
+    chem_gene_stmts = ac.load_statements(args.chemical_gene)
+    gene_dis_stmts = ac.load_statements(args.gene_disease)
+    all_ctd_stmts = chem_dis_stmts + chem_gene_stmts + gene_dis_stmts
+
+    # Collect all groundings for all agents in model statements and tests
+    groundings = get_all_groundings(all_model_stmts)
+    filtered_stmts = filter_by_groundings(all_ctd_stmts, groundings)
+    fname = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         '..', 'stmts', 'ctd_stmts.pkl')
+    with open(fname, 'wb') as fh:
+        pickle.dump(filtered_stmts, fh)

--- a/covid_19/process_virhostnet.py
+++ b/covid_19/process_virhostnet.py
@@ -1,0 +1,59 @@
+import logging
+import os
+import pickle
+from indra.sources.virhostnet import process_from_web
+
+
+logger = logging.getLogger(__name__)
+
+
+virus_taxonomy_ids = {
+    'avian CoV': '694014',
+    'bat CoV': '1508220',
+    'bovine CoV': '11128',
+    'canine coronavirus': '11153',
+    'canine CoV': '11153',
+    'Chikungunya': '37124',
+    'Ebolavirus': '186536',
+    'Enterovirus 68': '42789',
+    'equine CoV': '136187',
+    'feline coronavirus': '12663',
+    'feline CoV': '12663',
+    'Human CoV 229E': '11137',
+    'Human CoV HKU1': '290028',
+    'Human CoV NL63': '277944',
+    'Human CoV OC43': '31631',
+    'Lassa': '11620',
+    'MERS-CoV': '1335626',
+    'murine coronavirus': '694005',
+    'murine CoV': '694005',
+    'Nipah': '121791',
+    'porcine CoV': '694013',
+    'Rift Valley': '11588',
+    'SARS-CoV': '694009',
+    'SARS-CoV-2': '2697049',
+    'Zika virus': '64320',
+}
+
+
+def filter_to_tax_ids(stmts, virus_tax_ids, gene_tax_ids):
+    logger.info('Filtering %d statements for taxonomy IDs' % len(stmts))
+    stmts_out = []
+    for stmt in stmts:
+        if stmt.evidence[0].annotations['vir_tax'] in virus_tax_ids and \
+                stmt.evidence[0].annotations['host_tax'] in gene_tax_ids:
+            stmts_out.append(stmt)
+    logger.info('%d statements after filter' % len(stmts_out))
+    return stmts_out
+
+
+if __name__ == '__main__':
+    # Get all INDRA statements from VirHostNet
+    vp = process_from_web()
+    # Filter to only included viruses in virus_taxonomy_ids map and human genes
+    stmts = filter_to_tax_ids(
+        vp.statements, virus_taxonomy_ids.values(), ['9606'])
+    fname = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         '..', 'stmts', 'virhostnet_stmts.pkl')
+    with open(fname, 'wb') as fh:
+        pickle.dump(stmts, fh)


### PR DESCRIPTION
This PR adds new scripts to process and filter statements from VirHostNet and ctd. It also generalizes the `make_model_stmts` function by replacing `gordon_stmts` and `drug_stmts` arguments with one `other_stmts` that takes a list of any statements to be added to the model after CORD19 processing/filtering is done. `emmaa_update.py` script is updated to include virhostnet statements. 