### PR TITLE
Filter statements by reading date

### DIFF
--- a/covid_19/emmaa_update.py
+++ b/covid_19/emmaa_update.py
@@ -73,7 +73,7 @@ def make_model_stmts(old_mm_stmts, other_stmts, new_cord_stmts=None):
         logger.info('Found %d TextRefs, %d of which are not in old model'
                     % (len(tr_dicts), len(new_tr_dicts)))
         # Get statements for new text re
-        new_cord_stmts = get_raw_stmts(new_tr_dicts)
+        new_cord_stmts = get_raw_stmts(new_tr_dicts, date_limit=5)
 
     logger.info('Processing the statements')
     # Filter out ungrounded statements

--- a/covid_19/process_ctd.py
+++ b/covid_19/process_ctd.py
@@ -73,7 +73,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # Load model statements and tests
-    model_stmts = get_assembled_statements('covid19')
+    model_stmts, _ = get_assembled_statements('covid19')
     curated_tests, _ = load_tests_from_s3('covid19_curated_tests')
     if isinstance(curated_tests, dict):  # if descriptions were added
         curated_tests = curated_tests['tests']


### PR DESCRIPTION
This PR allows to only search the database for statements read within the specified date limit. EMMAA model is set to search up to 5 days back.