### PR TITLE
Papers

### DIFF
--- a/covid_19/add_to_indra_db.py
+++ b/covid_19/add_to_indra_db.py
@@ -2,7 +2,7 @@ import logging
 import pandas as pd
 from collections import defaultdict
 from indra.util import batch_iter
-from indra_db import get_primary_db
+from indra_db.util import get_db
 from indra.literature import id_lookup
 from indra.literature import pubmed_client
 from indra_db.managers import content_manager
@@ -250,6 +250,6 @@ if __name__ == '__main__':
     md = [e for e in md if e['doi'] and
                            e['doi'].upper() != '0.1126/SCIENCE.ABB7331']
     cm = Cord19Manager(md)
-    db = get_primary_db()
+    db = get_db('primary')
     res = cm.populate(db)
 

--- a/covid_19/emmaa_update.py
+++ b/covid_19/emmaa_update.py
@@ -55,6 +55,8 @@ def make_model_stmts(old_mm_stmts, other_stmts, new_cord_stmts=None):
     -------
     combined_stmts : list[indra.statements.Statement]
         A list of statements to make a new model from.
+    paper_ids : list[str]
+        A list of TRIDs associated with statements.
     """
     # If new cord statements are not provided, load from database
     if not new_cord_stmts:
@@ -91,7 +93,7 @@ def make_model_stmts(old_mm_stmts, other_stmts, new_cord_stmts=None):
     # Now, add back in all other statements
     combined_stmts = updated_mm_stmts + other_stmts
     logger.info('Got %d total statements.' % len(combined_stmts))
-    return combined_stmts
+    return combined_stmts, updated_mm_stmts_by_tr.keys()
 
 if __name__ == '__main__':
     # Example:
@@ -145,7 +147,7 @@ if __name__ == '__main__':
 
     other_stmts = drug_stmts + gordon_stmts + virhostnet_stmts + ctd_stmts
 
-    combined_stmts = make_model_stmts(
+    combined_stmts, _ = make_model_stmts(
         old_mm_stmts, other_stmts, new_cord_stmts)
 
     # Dump new pickle

--- a/covid_19/emmaa_update.py
+++ b/covid_19/emmaa_update.py
@@ -93,6 +93,7 @@ def make_model_stmts(old_mm_stmts, other_stmts, new_cord_stmts=None):
     # Now, add back in all other statements
     combined_stmts = updated_mm_stmts + other_stmts
     logger.info('Got %d total statements.' % len(combined_stmts))
+    logger.info('Processed %d papers.' % len(updated_mm_stmts_by_tr))
     return combined_stmts, updated_mm_stmts_by_tr.keys()
 
 if __name__ == '__main__':

--- a/covid_19/find_mutations.py
+++ b/covid_19/find_mutations.py
@@ -2,7 +2,7 @@ import re
 import csv
 from covid_19.preprocess import get_metadata_dict, get_zip_texts_for_entry, \
                                 get_metadata_df, get_all_texts
-from indra_db import get_primary_db
+from indra_db.util import get_db
 
 
 covid_docs_file = '../covid_docs_ranked_corona.csv'

--- a/covid_19/get_indra_stmts.py
+++ b/covid_19/get_indra_stmts.py
@@ -10,7 +10,7 @@ from itertools import groupby
 from collections import defaultdict
 from os.path import abspath, dirname, join
 from indra.util import batch_iter
-from indra_db import get_primary_db
+from indra_db.util import get_db
 from indra_db.util import distill_stmts
 from indra.statements import stmts_from_json, stmts_to_json
 from indra.tools import assemble_corpus as ac
@@ -34,7 +34,7 @@ def get_unique_text_refs():
     pmids = [fix_pmid(pmid) for pmid in get_ids('pubmed_id')]
     dois = [fix_doi(doi) for doi in get_ids('doi')]
     # Get unique text_refs from the DB
-    db = get_primary_db()
+    db = get_db('primary')
     print("Getting TextRefs by PMCID")
     tr_pmcids = db.select_all(db.TextRef.id, db.TextRef.pmcid_in(pmcids))
     print("Getting TextRefs by PMID")
@@ -57,7 +57,7 @@ def get_text_refs_for_pubmed_search_term(search_term, **kwargs):
     print('Searching for %s' % search_term)
     pmids = pubmed_client.get_ids(search_term, **kwargs)
     print('Getting TextRefs for %d PMIDs' % len(pmids))
-    db = get_primary_db()
+    db = get_db('primary')
     tr_pmids = db.select_all(db.TextRef.id, db.TextRef.pmid_in(pmids))
     trids = {res.id for res in tr_pmids}
     return trids
@@ -97,7 +97,7 @@ def get_indradb_pa_stmts():
 
 
 def get_reach_readings(tr_dicts, dump_dir=None):
-    db = get_primary_db()
+    db = get_db('primary')
     # Get text ref dicts with article metadata aligned between DB and CORD19
     # Get REACH readings 
     reach_data = db.select_all((db.Reading, db.TextRef,
@@ -165,7 +165,7 @@ def get_raw_stmts(tr_dicts, date_limit=None):
         Raw INDRA Statements retrieved from the INDRA DB.
     """
     # Get raw statement IDs from the DB for the given TextRefs
-    db = get_primary_db()
+    db = get_db('primary')
     # Get statements for the given text refs
     text_ref_ids = list(tr_dicts.keys())
     print(f"Distilling statements for {len(text_ref_ids)} TextRefs")

--- a/covid_19/rank_docs.py
+++ b/covid_19/rank_docs.py
@@ -6,7 +6,7 @@ from indra.preassembler import Preassembler
 from indra.ontology.bio import bio_ontology
 from indra.tools import assemble_corpus as ac
 from indra.databases.mesh_client import mesh_id_to_tree_numbers, get_mesh_name
-from indra_db import get_primary_db
+from indra_db import get_db
 from covid_19.emmaa_update import stmts_by_text_refs
 from covid_19.preprocess import get_metadata_dict
 
@@ -49,7 +49,7 @@ def get_cord_info():
 
 
 def get_pmids_for_mesh_terms(mesh_list):
-    db = get_primary_db()
+    db = get_db('primary')
     res = db.select_all(db.MeshRefAnnotations.pmid,
                         db.MeshRefAnnotations.mesh_id.in_(mesh_list))
     return [t[0] for t in res]


### PR DESCRIPTION
This PR updates the `make_model_stmts` function to return the TRIDs of the papers along with the statements. It also replaces deprecated `get_primary_db` function with recommended `get_db('primary')`.