### PR TITLE
Update EMMAA related script

### DIFF
--- a/covid_19/emmaa_update.py
+++ b/covid_19/emmaa_update.py
@@ -36,24 +36,24 @@ def combine_stmts(new_cord_by_tr, old_mm_by_tr):
     return stmts_copy
 
 
-def make_model_stmts(old_mm_stmts, other_stmts, new_cord_stmts=None):
+def make_model_stmts(old_mm_stmts, new_cord_stmts=None, date_limit=5):
     """Process and combine statements from different resources.
 
     Parameters
     ----------
     old_mm_stmts : list[indra.statements.Statement]
         A list of statements currently in the model.
-    other_stmts : list[indra.statements.Statement]
-        A list of statements that do not need additional processing
-        (e.g. drug, gordon, virhostnet statements).
     new_cord_stmts : Optional[list[indra.statements.Statement]]
         A list of newly extracted statements from CORD19 corpus. If not
         provided, the statements are pulled from the database and filtered
         to those not in old_mm_stmts.
-    
+    date_limit : Optional[int]
+        How many days back to search the database for CORD19 statements.
+        Default: 5.
+
     Returns
     -------
-    combined_stmts : list[indra.statements.Statement]
+    updated_mm_stmts : list[indra.statements.Statement]
         A list of statements to make a new model from.
     paper_ids : list[str]
         A list of TRIDs associated with statements.
@@ -75,7 +75,7 @@ def make_model_stmts(old_mm_stmts, other_stmts, new_cord_stmts=None):
         logger.info('Found %d TextRefs, %d of which are not in old model'
                     % (len(tr_dicts), len(new_tr_dicts)))
         # Get statements for new text re
-        new_cord_stmts = get_raw_stmts(new_tr_dicts, date_limit=5)
+        new_cord_stmts = get_raw_stmts(new_tr_dicts, date_limit=date_limit)
 
     logger.info('Processing the statements')
     # Filter out ungrounded statements
@@ -90,11 +90,9 @@ def make_model_stmts(old_mm_stmts, other_stmts, new_cord_stmts=None):
     updated_mm_stmts = [s for stmt_list in updated_mm_stmts_by_tr.values()
                           for s in stmt_list]
 
-    # Now, add back in all other statements
-    combined_stmts = updated_mm_stmts + other_stmts
-    logger.info('Got %d total statements.' % len(combined_stmts))
+    logger.info('Got %d total statements.' % len(updated_mm_stmts))
     logger.info('Processed %d papers.' % len(updated_mm_stmts_by_tr))
-    return combined_stmts, updated_mm_stmts_by_tr.keys()
+    return updated_mm_stmts, updated_mm_stmts_by_tr.keys()
 
 if __name__ == '__main__':
     # Example:

--- a/covid_19/emmaa_update.py
+++ b/covid_19/emmaa_update.py
@@ -146,8 +146,9 @@ if __name__ == '__main__':
 
     other_stmts = drug_stmts + gordon_stmts + virhostnet_stmts + ctd_stmts
 
-    combined_stmts, _ = make_model_stmts(
+    model_stmts, _ = make_model_stmts(
         old_model_stmts, new_cord_stmts)
 
+    combined_stmts = model_stmts + other_stmts
     # Dump new pickle
     ac.dump_statements(combined_stmts, args.output_file)

--- a/covid_19/emmaa_update.py
+++ b/covid_19/emmaa_update.py
@@ -2,7 +2,6 @@ import pickle
 import argparse
 import logging
 from copy import copy
-from os.path import join, dirname, abspath
 from indra.tools import assemble_corpus as ac
 from covid_19.get_indra_stmts import get_tr_dicts_and_ids, get_raw_stmts
 
@@ -28,32 +27,32 @@ def stmts_by_text_refs(stmt_list):
     return by_tr, no_tr
 
 
-def combine_stmts(new_cord_by_tr, old_mm_by_tr):
+def combine_stmts(new_cord_by_tr, old_model_by_tr):
     stmts_copy = copy(new_cord_by_tr)
-    for trid, stmts in old_mm_by_tr.items():
+    for trid, stmts in old_model_by_tr.items():
         if trid not in stmts_copy:
             stmts_copy[trid] = stmts
     return stmts_copy
 
 
-def make_model_stmts(old_mm_stmts, new_cord_stmts=None, date_limit=5):
+def make_model_stmts(old_model_stmts, new_cord_stmts=None, date_limit=5):
     """Process and combine statements from different resources.
 
     Parameters
     ----------
-    old_mm_stmts : list[indra.statements.Statement]
+    old_model_stmts : list[indra.statements.Statement]
         A list of statements currently in the model.
     new_cord_stmts : Optional[list[indra.statements.Statement]]
         A list of newly extracted statements from CORD19 corpus. If not
         provided, the statements are pulled from the database and filtered
-        to those not in old_mm_stmts.
+        to those not in old_model_stmts.
     date_limit : Optional[int]
         How many days back to search the database for CORD19 statements.
         Default: 5.
 
     Returns
     -------
-    updated_mm_stmts : list[indra.statements.Statement]
+    updated_model_stmts : list[indra.statements.Statement]
         A list of statements to make a new model from.
     paper_ids : list[str]
         A list of TRIDs associated with statements.
@@ -61,11 +60,11 @@ def make_model_stmts(old_mm_stmts, new_cord_stmts=None, date_limit=5):
     # If new cord statements are not provided, load from database
     if not new_cord_stmts:
         # Get text refs from metadata
-        tr_dicts, multiple_tr_ids = get_tr_dicts_and_ids()
+        tr_dicts, _ = get_tr_dicts_and_ids()
         # Filter to text refs that are not part of old model
         new_tr_dicts = {}
         old_tr_ids = set()
-        for stmt in old_mm_stmts: 
+        for stmt in old_model_stmts: 
             for evid in stmt.evidence: 
                 if evid.text_refs.get('TRID'): 
                     old_tr_ids.add(evid.text_refs['TRID'])
@@ -82,17 +81,18 @@ def make_model_stmts(old_mm_stmts, new_cord_stmts=None, date_limit=5):
     new_cord_grounded = ac.filter_grounded_only(new_cord_stmts)
 
     # Group statements by TextRef
-    old_mm_by_tr, old_mm_no_tr = stmts_by_text_refs(old_mm_stmts)
-    new_cord_by_tr, new_cord_no_tr = stmts_by_text_refs(new_cord_grounded)
+    old_model_by_tr, _ = stmts_by_text_refs(old_model_stmts)
+    new_cord_by_tr, _ = stmts_by_text_refs(new_cord_grounded)
 
     # Add any EMMAA statements from non-Cord19 publications
-    updated_mm_stmts_by_tr = combine_stmts(new_cord_by_tr, old_mm_by_tr)
-    updated_mm_stmts = [s for stmt_list in updated_mm_stmts_by_tr.values()
-                          for s in stmt_list]
+    updated_model_stmts_by_tr = combine_stmts(new_cord_by_tr, old_model_by_tr)
+    updated_model_stmts = [
+        s for stmt_list in updated_model_stmts_by_tr.values()
+        for s in stmt_list]
 
-    logger.info('Got %d total statements.' % len(updated_mm_stmts))
-    logger.info('Processed %d papers.' % len(updated_mm_stmts_by_tr))
-    return updated_mm_stmts, updated_mm_stmts_by_tr.keys()
+    logger.info('Got %d total statements.' % len(updated_model_stmts))
+    logger.info('Processed %d papers.' % len(updated_model_stmts_by_tr))
+    return updated_model_stmts, updated_model_stmts_by_tr.keys()
 
 if __name__ == '__main__':
     # Example:
@@ -107,7 +107,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
             description='Put together updated statement pkl for COVID-19 '
                         'EMMAA model.')
-    parser.add_argument('-om', '--old_mm',
+    parser.add_argument('-om', '--old_model',
                         help='Name of old EMMAA model pkl file',
                         required=True)
     parser.add_argument('-nc', '--new_cord',
@@ -132,9 +132,9 @@ if __name__ == '__main__':
 
     # Load everything
     logger.info('Loading statements from pickle files')
-    with open(args.old_mm, 'rb') as f:
-        old_mm_emmaa_stmts = pickle.load(f)
-        old_mm_stmts = [es.stmt for es in old_mm_emmaa_stmts]
+    with open(args.old_model, 'rb') as f:
+        old_model_emmaa_stmts = pickle.load(f)
+        old_model_stmts = [es.stmt for es in old_model_emmaa_stmts]
     if args.new_cord:
         new_cord_stmts = ac.load_statements(args.new_cord)
     else:
@@ -147,7 +147,7 @@ if __name__ == '__main__':
     other_stmts = drug_stmts + gordon_stmts + virhostnet_stmts + ctd_stmts
 
     combined_stmts, _ = make_model_stmts(
-        old_mm_stmts, other_stmts, new_cord_stmts)
+        old_model_stmts, new_cord_stmts)
 
     # Dump new pickle
     ac.dump_statements(combined_stmts, args.output_file)


### PR DESCRIPTION
This PR makes removes `other_stmts` parameter from `make_model_stmts` function (they can be added separately), adds `date_limit` as a parameter (how many days back to look) and updates some variable names to avoid confusion. The `emmaa_update.py` script itself is updated accordingly. 